### PR TITLE
fix: explicit import nuxt types

### DIFF
--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "tsconfig/nuxt.json",
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".nuxt/nuxt.d.ts"],
   "exclude": ["node_modules"],
 	"compilerOptions": {
 		"paths": {

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "tsconfig/nuxt.json",
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".nuxt/nuxt.d.ts"],
   "exclude": ["node_modules"],
 	"compilerOptions": {
 		"paths": {


### PR DESCRIPTION
This is a workaround for #5, before typescript 5.0.0 is stable.
With typescript 5, we should migrate to entierly import .nuxt/tsconfig.json
alongside our tsconfig/nuxt.json.
Maybe it's even possible to include the nuxt tsconfig in our share nuxt.json.
